### PR TITLE
No js no banner

### DIFF
--- a/application/static/stylesheets/dl-frontend.css
+++ b/application/static/stylesheets/dl-frontend.css
@@ -10520,14 +10520,8 @@
   background: transparent;
 }
 
-.dl-timeline__filter {
-  display: none;
-}
-
-.dl-js-enhancement {
-  display: none;
-}
-
+.dl-timeline__filter,
+.dl-js-enhancement,
 .global-cookie-message {
   display: none;
 }
@@ -10553,14 +10547,8 @@
   visibility: hidden;
 }
 
-.js-enabled .dl-timeline__filter {
-  display: block;
-}
-
-.js-enabled .dl-js-enhancement {
-  display: block;
-}
-
+.js-enabled .dl-timeline__filter,
+.js-enabled .dl-js-enhancement,
 .js-enabled .global-cookie-message {
   display: block;
 }

--- a/application/static/stylesheets/dl-frontend.css
+++ b/application/static/stylesheets/dl-frontend.css
@@ -10528,6 +10528,10 @@
   display: none;
 }
 
+.global-cookie-message {
+  display: none;
+}
+
 .js-enabled .hub-list__separator:first-of-type {
   display: none;
 }
@@ -10554,6 +10558,10 @@
 }
 
 .js-enabled .dl-js-enhancement {
+  display: block;
+}
+
+.js-enabled .global-cookie-message {
   display: block;
 }
 

--- a/application/templates/dl-partials/cookie-banner.html
+++ b/application/templates/dl-partials/cookie-banner.html
@@ -1,4 +1,4 @@
-<div id="global-cookie-message" class="govuk-clearfix" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="" style="display: block;">
+<div id="global-cookie-message" class="govuk-clearfix global-cookie-message" data-module="cookie-banner" role="region" aria-label="cookie banner" data-nosnippet="">
 
   <div id="cookie-banner" class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/src/scss/dl-frontend.scss
+++ b/src/scss/dl-frontend.scss
@@ -165,16 +165,9 @@ a {
   background: transparent;
 }
 
-// for covid-19 project
-
-.dl-timeline__filter {
-  display: none;
-}
-
-.dl-js-enhancement {
-  display: none;
-}
-
+// hide some elements and show if javascript enabled
+.dl-timeline__filter,
+.dl-js-enhancement,
 .global-cookie-message {
   display: none;
 }
@@ -203,14 +196,8 @@ a {
     visibility: hidden;
   }
 
-  .dl-timeline__filter {
-    display: block;
-  }
-
-  .dl-js-enhancement {
-    display: block;
-  }
-
+  .dl-timeline__filter,
+  .dl-js-enhancement,
   .global-cookie-message {
     display: block;
   }

--- a/src/scss/dl-frontend.scss
+++ b/src/scss/dl-frontend.scss
@@ -175,6 +175,10 @@ a {
   display: none;
 }
 
+.global-cookie-message {
+  display: none;
+}
+
 .js-enabled {
   .hub-list__separator:first-of-type {
     display: none;
@@ -204,6 +208,10 @@ a {
   }
 
   .dl-js-enhancement {
+    display: block;
+  }
+
+  .global-cookie-message {
     display: block;
   }
 }


### PR DESCRIPTION
We decided that because, currently, our cookies are only set by client-side javascript we do not need to show the cookie consent banner if a user does not have js enabled.

This might change in the future if we chose to set cookies using a different method.